### PR TITLE
fix(script): fix typo of update_subscriptions.uc

### DIFF
--- a/root/etc/homeproxy/scripts/update_subscriptions.uc
+++ b/root/etc/homeproxy/scripts/update_subscriptions.uc
@@ -246,7 +246,7 @@ function parse_uri(uri) {
 			if (!uri)
 				return null;
 
-			const userinfo = split(uri[0], ':'),
+			const userinfo = split(uri[0], ':');
 			params = urldecode_params(uri[1]);
 
 			if (!sing_features.with_shadowsocksr) {


### PR DESCRIPTION
Running under vanilla Openwrt will produce the following error
```
root@Openwrt:~# /etc/homeproxy/scripts/update_subscriptions.uc
Syntax error: Invalid assignment to constant 'params'
In /etc/homeproxy/scripts/update_subscriptions.uc, line 276, byte 32:

 `            params = url.searchParams || {};`
  Near here -------------------------------^


Syntax error: Invalid assignment to constant 'params'
In /etc/homeproxy/scripts/update_subscriptions.uc, line 309, byte 32:

 `            params = url.searchParams || {};`
  Near here -------------------------------^


Syntax error: Invalid assignment to constant 'params'
In /etc/homeproxy/scripts/update_subscriptions.uc, line 336, byte 16:

 `            params = url.searchParams;`
  Near here ---------------^
```