### PR TITLE
feat(client): Added a prompt for the user to choose whether to install Tun

### DIFF
--- a/htdocs/luci-static/resources/view/homeproxy/client.js
+++ b/htdocs/luci-static/resources/view/homeproxy/client.js
@@ -245,6 +245,8 @@ return view.extend({
 		if (features.hp_has_ip_full && features.hp_has_tun) {
 			o.value('redirect_tun', _('Redirect TCP + Tun UDP'));
 			o.value('tun', _('Tun TCP/UDP'));
+		} else {
+			o.description = _('To enable Tun support, you need to install <b>%s</b><br/>').format(['ip-full', 'kmod-tun']);
 		}
 		o.default = 'redirect_tproxy';
 		o.rmempty = false;

--- a/htdocs/luci-static/resources/view/homeproxy/client.js
+++ b/htdocs/luci-static/resources/view/homeproxy/client.js
@@ -246,7 +246,7 @@ return view.extend({
 			o.value('redirect_tun', _('Redirect TCP + Tun UDP'));
 			o.value('tun', _('Tun TCP/UDP'));
 		} else {
-			o.description = _('To enable Tun support, you need to install <b>%s</b><br/>').format(['ip-full', 'kmod-tun']);
+			o.description = _('To enable Tun support, you need to install <code>ip-full</code> and <code>kmod-tun</code>');
 		}
 		o.default = 'redirect_tproxy';
 		o.rmempty = false;


### PR DESCRIPTION
homeproxy enables tun by checking multiple dependencies [code](https://github.com/immortalwrt/homeproxy/blob/master/htdocs/luci-static/resources/view/homeproxy/client.js#L245) [code2](https://github.com/immortalwrt/homeproxy/blob/master/root/usr/share/rpcd/ucode/luci.homeproxy#L175), of which `ip-full` is missing
