### PR TITLE
feat(generator/client): Add more options support

### DIFF
--- a/htdocs/luci-static/resources/view/homeproxy/client.js
+++ b/htdocs/luci-static/resources/view/homeproxy/client.js
@@ -713,6 +713,16 @@ return view.extend({
 		so.rmempty = false;
 		so.readonly = true;
 
+		so = ss.option(form.ListValue, 'ip_version', _('IP Version'));
+		so.value('4', _('IPv4'));
+		so.value('6', _('IPv6'));
+		so.value('', _('Both'));
+		so.modalonly = true;
+
+		so = ss.option(form.DynamicList, 'query_type', _('Query type'),
+			_('Match query type.'));
+		so.modalonly = true;
+
 		so = ss.option(form.ListValue, 'network', _('Network'));
 		so.value('tcp', _('TCP'));
 		so.value('udp', _('UDP'));
@@ -833,6 +843,11 @@ return view.extend({
 		so = ss.option(form.Flag, 'dns_disable_cache', _('Disable dns cache'),
 			_('Disable cache and save cache in this query.'));
 		so.default = so.disabled;
+		so.modalonly = true;
+
+		so = ss.option(form.Value, 'rewrite_ttl', _('Rewrite TTL'),
+			_('Rewrite TTL in DNS responses.'));
+		so.datatype = 'uinteger';
 		so.modalonly = true;
 		/* DNS rules end */
 		/* Custom routing settings end */

--- a/htdocs/luci-static/resources/view/homeproxy/client.js
+++ b/htdocs/luci-static/resources/view/homeproxy/client.js
@@ -421,6 +421,18 @@ return view.extend({
 		so.rmempty = false;
 		so.editable = true;
 
+		so = ss.option(form.ListValue, 'mode', _('Mode'),
+			_('The default rule uses the following matching logic:<br/>' +
+			'<code>(domain || domain_suffix || domain_keyword || domain_regex || geosite || geoip || ip_cidr)</code> &&<br/>' +
+			'<code>(port || port_range)</code> &&<br/>' +
+			'<code>(source_geoip || source_ip_cidr)</code> &&<br/>' +
+			'<code>(source_port || source_port_range)</code> &&<br/>' +
+			'<code>other fields</code>.'));
+		so.value('default', _('Default'));
+		so.default = 'default';
+		so.rmempty = false;
+		so.readonly = true;
+
 		so = ss.option(form.ListValue, 'ip_version', _('IP version'),
 			_('4 or 6. Not limited if empty.'));
 		so.value('4', _('IPv4'));
@@ -428,32 +440,17 @@ return view.extend({
 		so.value('', _('Both'));
 		so.modalonly = true;
 
-		so = ss.option(form.ListValue, 'mode', _('Mode'),
-			_('The default rule uses the following matching logic:<br/>' +
-			'<code>(domain || domain_suffix || domain_keyword || domain_regex || geosite || geoip || ip_cidr)</code> &&<br/>' +
-			'<code>(source_geoip || source_ip_cidr)</code> &&<br/>' +
-			'<code>other fields</code>.'));
-		so.value('default', _('Default'));
-		so.default = 'default';
-		so.rmempty = false;
-		so.readonly = true;
-
-		so = ss.option(form.Flag, 'invert', _('Invert'),
-			_('Invert match result.'));
-		so.default = so.disabled;
-		so.modalonly = true;
-
-		so = ss.option(form.ListValue, 'network', _('Network'));
-		so.value('tcp', _('TCP'));
-		so.value('udp', _('UDP'));
-		so.value('', _('Both'));
-
 		so = ss.option(form.MultiValue, 'protocol', _('Protocol'),
 			_('Sniffed protocol, see <a target="_blank" href="https://sing-box.sagernet.org/configuration/route/sniff/">Sniff</a> for details.'));
 		so.value('http', _('HTTP'));
 		so.value('tls', _('TLS'));
 		so.value('quic', _('QUIC'));
 		so.value('stun', _('STUN'));
+
+		so = ss.option(form.ListValue, 'network', _('Network'));
+		so.value('tcp', _('TCP'));
+		so.value('udp', _('UDP'));
+		so.value('', _('Both'));
 
 		so = ss.option(form.DynamicList, 'domain', _('Domain name'),
 			_('Match full domain.'));
@@ -524,6 +521,11 @@ return view.extend({
 
 		so = ss.option(form.DynamicList, 'user', _('User'),
 			_('Match user name.'));
+		so.modalonly = true;
+
+		so = ss.option(form.Flag, 'invert', _('Invert'),
+			_('Invert match result.'));
+		so.default = so.disabled;
 		so.modalonly = true;
 
 		so = ss.option(form.ListValue, 'outbound', _('Outbound'),

--- a/htdocs/luci-static/resources/view/homeproxy/client.js
+++ b/htdocs/luci-static/resources/view/homeproxy/client.js
@@ -580,6 +580,11 @@ return view.extend({
 		so = ss.option(form.Flag, 'disable_cache_expire', _('Disable cache expire'));
 		so.default = so.disabled;
 		so.depends('disable_cache', '0');
+
+		so = ss.option(form.Flag, 'independent_cache', _('Independent cache per server'),
+			_('Make each DNS server\'s cache independent for special purposes. If enabled, will slightly degrade performance.'));
+		so.default = so.disabled;
+		so.depends('disable_cache', '0');
 		/* DNS settings end */
 
 		/* DNS servers start */

--- a/root/etc/homeproxy/scripts/generate_client.uc
+++ b/root/etc/homeproxy/scripts/generate_client.uc
@@ -48,7 +48,7 @@ const dns_port = uci.get(uciconfig, uciinfra, 'dns_port') || '5333';
 
 let main_node, main_udp_node, dedicated_udp_node, default_outbound, sniff_override = '1',
     dns_server, dns_default_strategy, dns_default_server, dns_disable_cache, dns_disable_cache_expire,
-    direct_domain_list;
+    dns_independent_cache, direct_domain_list;
 
 if (routing_mode !== 'custom') {
 	main_node = uci.get(uciconfig, ucimain, 'main_node') || 'nil';
@@ -68,6 +68,7 @@ if (routing_mode !== 'custom') {
 	dns_default_server = uci.get(uciconfig, ucidnssetting, 'default_server');
 	dns_disable_cache = uci.get(uciconfig, ucidnssetting, 'disable_cache');
 	dns_disable_cache_expire = uci.get(uciconfig, ucidnssetting, 'disable_cache_expire');
+	dns_independent_cache = uci.get(uciconfig, ucidnssetting, 'independent_cache');
 
 	/* Routing settings */
 	default_outbound = uci.get(uciconfig, uciroutingsetting, 'default_outbound') || 'nil';
@@ -308,7 +309,8 @@ config.dns = {
 	rules: [],
 	strategy: dns_default_strategy,
 	disable_cache: (dns_disable_cache === '1'),
-	disable_expire: (dns_disable_cache_expire === '1')
+	disable_expire: (dns_disable_cache_expire === '1'),
+	independent_cache: (dns_independent_cache === '1')
 };
 
 if (!isEmpty(main_node)) {

--- a/root/etc/homeproxy/scripts/generate_client.uc
+++ b/root/etc/homeproxy/scripts/generate_client.uc
@@ -573,10 +573,9 @@ if (!isEmpty(main_node)) {
 			return null;
 
 		push(config.route.rules, {
-			invert: cfg.invert,
-			ip_version: cfg.ip_version,
-			network: cfg.network,
+			ip_version: strToInt(cfg.ip_version),
 			protocol: cfg.protocol,
+			network: cfg.network,
 			domain: cfg.domain,
 			domain_suffix: cfg.domain_suffix,
 			domain_keyword: cfg.domain_keyword,

--- a/root/etc/homeproxy/scripts/generate_client.uc
+++ b/root/etc/homeproxy/scripts/generate_client.uc
@@ -8,6 +8,7 @@
 'use strict';
 
 import { readfile, writefile } from 'fs';
+import { isnan } from 'math';
 import { cursor } from 'uci';
 
 import {
@@ -113,6 +114,18 @@ function parse_port(strport) {
 		push(ports, int(i));
 
 	return ports;
+
+}
+
+function parse_dnsquery(strquery) {
+	if (type(strquery) !== 'array' || isEmpty(strquery))
+		return null;
+
+	let querys = [];
+	for (let i in strquery)
+		isnan(int(i)) ? push(querys, i) : push(querys, int(i));
+
+	return querys;
 
 }
 
@@ -377,6 +390,8 @@ if (!isEmpty(main_node)) {
 			return;
 
 		push(config.dns.rules, {
+			ip_version: strToInt(cfg.ip_version),
+			query_type: parse_dnsquery(cfg.query_type),
 			network: cfg.network,
 			protocol: cfg.protocol,
 			domain: cfg.domain,
@@ -396,7 +411,8 @@ if (!isEmpty(main_node)) {
 			invert: (cfg.invert === '1'),
 			outbound: get_outbound(cfg.outbound),
 			server: get_resolver(cfg.server),
-			disable_cache: (cfg.dns_disable_cache === '1')
+			disable_cache: (cfg.dns_disable_cache === '1'),
+			rewrite_ttl: strToInt(cfg.rewrite_ttl)
 		});
 	});
 


### PR DESCRIPTION
1. Add DNS global options
    - \+ dns.independent_cache
    - \+ dns.reverse_mapping
2. Add System DNS server `address: 'local'` for resolving custom private domain
    - \+ dns.servers[1]
3. DNS rules
    - \- homeproxy.@dns_rule[-1].ip_cidr
    - \+ dns.rules.query_type
    - \+ dns.rules.ip_version
    - \+ dns.rules.auth_user
    - \+ dns.rules.user_id
    - \+ dns.rules.clash_mode
    - \+ dns.rules.rewrite_ttl
    - Allow `dns.rules.outbound: 'any'`
3. Route rules
    - \+ route.rules.auth_user
    - \+ route.rules.user_id
    - \+ route.rules.clash_mode