### PR TITLE
Keep nodes that have duplicate configs but names is not

### DIFF
--- a/root/etc/homeproxy/scripts/update_subscriptions.uc
+++ b/root/etc/homeproxy/scripts/update_subscriptions.uc
@@ -484,7 +484,6 @@ function main() {
 				continue;
 
 			const label = config.label;
-			config.label = null;
 			const confHash = calcStringMD5(sprintf('%J', config)),
 			      nameHash = calcStringMD5(label);
 			config.label = label;


### PR DESCRIPTION
Like this:
![image](https://github.com/user-attachments/assets/1c89cd13-4954-44f6-8ef9-a9e8adc3b013)
