### PR TITLE
chinadns update ipset need root

### DIFF
--- a/root/etc/init.d/homeproxy
+++ b/root/etc/init.d/homeproxy
@@ -211,8 +211,8 @@ start_service() {
 					procd_add_jail_mount "$HP_DIR/resources/gfw_list.txt"
 					procd_set_param capabilities "/etc/capabilities/homeproxy.json"
 					procd_set_param no_new_privs 1
-					procd_set_param user sing-box
-					procd_set_param group sing-box
+					procd_set_param user root
+					procd_set_param group root
 				fi
 
 				procd_set_param limits core="unlimited"


### PR DESCRIPTION
使用sing-box时ipset更新功能不生效，基于域名的ip分流不符合预期。