### PR TITLE
A possible solution to work with mwan3  together

### DIFF
--- a/root/etc/homeproxy/scripts/firewall_post.ut
+++ b/root/etc/homeproxy/scripts/firewall_post.ut
@@ -60,7 +60,7 @@ const proxy_mode = uci.get(cfgname, 'config', 'proxy_mode') || 'redirect_tproxy'
 let self_mark, redirect_port,
     tproxy_port, tproxy_mark,
     tun_name, tun_mark;
-
+const fwmask = uci.get(cfgname, 'infra', 'fwmask') || '0xffffff00';
 if (match(proxy_mode, /redirect/)) {
 	self_mark = uci.get(cfgname, 'infra', 'self_mark') || '100';
 	redirect_port = uci.get(cfgname, 'infra', 'redirect_port') || '5331';
@@ -564,7 +564,7 @@ chain homeproxy_mangle_tun_mark {
 	udp dport != @homeproxy_routing_port counter return
 	{% endif /* routing_port */ %}
 
-	counter mark set meta mark & 0xffffff00 | {{ tun_mark }}
+	counter mark set meta mark & {{fwmask}} | {{ tun_mark }}
 }
 
 chain homeproxy_mangle_tun {
@@ -621,13 +621,13 @@ chain homeproxy_mangle_tun {
 	{% endif /* routing_mode */ %}
 
 	{% if (!isEmpty(control_info.lan_gaming_mode_ipv4_ips)): %}
-	ip saddr {{ array_to_nftarr(control_info.lan_gaming_mode_ipv4_ips) }} counter mark set meta mark & 0xffffff00 |  {{ tun_mark }}
+	ip saddr {{ array_to_nftarr(control_info.lan_gaming_mode_ipv4_ips) }} counter mark set meta mark & {{fwmask}} |  {{ tun_mark }}
 	{% endif /* lan_gaming_mode_ipv4_ips */ %}
 	{% for (let ipv6 in control_info.lan_gaming_mode_ipv6_ips): %}
-	ip6 saddr {{ resolve_ipv6(ipv6) }} counter mark set meta mark & 0xffffff00 |  {{ tun_mark }}
+	ip6 saddr {{ resolve_ipv6(ipv6) }} counter mark set meta mark & {{fwmask}} |  {{ tun_mark }}
 	{% endfor /* lan_gaming_mode_ipv6_ips */ %}
 	{% if (!isEmpty(control_info.lan_gaming_mode_mac_addrs)): %}
-	ether saddr {{ array_to_nftarr(control_info.lan_gaming_mode_mac_addrs) }} counter mark set meta mark & 0xffffff00 | {{ tun_mark }}
+	ether saddr {{ array_to_nftarr(control_info.lan_gaming_mode_mac_addrs) }} counter mark set meta mark & {{fwmask}} | {{ tun_mark }}
 	{% endif /* lan_gaming_mode_mac_addrs */ %}
 
 	counter goto homeproxy_mangle_tun_mark

--- a/root/etc/homeproxy/scripts/firewall_post.ut
+++ b/root/etc/homeproxy/scripts/firewall_post.ut
@@ -564,7 +564,7 @@ chain homeproxy_mangle_tun_mark {
 	udp dport != @homeproxy_routing_port counter return
 	{% endif /* routing_port */ %}
 
-	counter mark set {{ tun_mark }}
+	counter mark set meta mark & 0xffffff00 | {{ tun_mark }}
 }
 
 chain homeproxy_mangle_tun {
@@ -621,13 +621,13 @@ chain homeproxy_mangle_tun {
 	{% endif /* routing_mode */ %}
 
 	{% if (!isEmpty(control_info.lan_gaming_mode_ipv4_ips)): %}
-	ip saddr {{ array_to_nftarr(control_info.lan_gaming_mode_ipv4_ips) }} counter mark set {{ tun_mark }}
+	ip saddr {{ array_to_nftarr(control_info.lan_gaming_mode_ipv4_ips) }} counter mark set meta mark & 0xffffff00 |  {{ tun_mark }}
 	{% endif /* lan_gaming_mode_ipv4_ips */ %}
 	{% for (let ipv6 in control_info.lan_gaming_mode_ipv6_ips): %}
-	ip6 saddr {{ resolve_ipv6(ipv6) }} counter mark set {{ tun_mark }}
+	ip6 saddr {{ resolve_ipv6(ipv6) }} counter mark set meta mark & 0xffffff00 |  {{ tun_mark }}
 	{% endfor /* lan_gaming_mode_ipv6_ips */ %}
 	{% if (!isEmpty(control_info.lan_gaming_mode_mac_addrs)): %}
-	ether saddr {{ array_to_nftarr(control_info.lan_gaming_mode_mac_addrs) }} counter mark set {{ tun_mark }}
+	ether saddr {{ array_to_nftarr(control_info.lan_gaming_mode_mac_addrs) }} counter mark set meta mark & 0xffffff00 | {{ tun_mark }}
 	{% endif /* lan_gaming_mode_mac_addrs */ %}
 
 	counter goto homeproxy_mangle_tun_mark

--- a/root/etc/init.d/homeproxy
+++ b/root/etc/init.d/homeproxy
@@ -114,8 +114,9 @@ start_service() {
 		/etc/init.d/dnsmasq restart >"/dev/null" 2>&1
 
 		# Setup routing table
-		local table_mark
+		local table_mark table_mask
 		config_get table_mark "infra" "table_mark" "100"
+		config_get table_mask "infra" "table_mask" "0xff"
 		case "$proxy_mode" in
 		"redirect_tproxy")
 			local outbound_udp_node
@@ -124,11 +125,11 @@ start_service() {
 				local tproxy_mark
 				config_get tproxy_mark "infra" "tproxy_mark" "101"
 
-				ip rule add fwmark "$tproxy_mark"/0xff table "$table_mark"
+				ip rule add fwmark "$tproxy_mark"/"$table_mask" table "$table_mark"
 				ip route add local 0.0.0.0/0 dev lo table "$table_mark"
 
 				if [ "$ipv6_support" -eq "1" ]; then
-					ip -6 rule add fwmark "$tproxy_mark"/0xff table "$table_mark"
+					ip -6 rule add fwmark "$tproxy_mark"/"$table_mask" table "$table_mark"
 					ip -6 route add local ::/0 dev lo table "$table_mark"
 				fi
 			fi
@@ -143,10 +144,10 @@ start_service() {
 			ip link set "$tun_name" up
 
 			ip route replace default dev "$tun_name" table "$table_mark"
-			ip rule add fwmark "$tun_mark"/0xff lookup "$table_mark"
+			ip rule add fwmark "$tun_mark"/"$table_mask" lookup "$table_mark"
 
 			ip -6 route replace default dev "$tun_name" table "$table_mark"
-			ip -6 rule add fwmark "$tun_mark"/0xff lookup "$table_mark"
+			ip -6 rule add fwmark "$tun_mark"/"$table_mask" lookup "$table_mark"
 			;;
 		esac
 
@@ -303,24 +304,25 @@ stop_service() {
 	# Setup firewall
 	# Load config
 	config_load "$CONF"
-	local table_mark tproxy_mark tun_mark tun_name
+	local table_mark table_mask tproxy_mark tun_mark tun_name
 	config_get table_mark "infra" "table_mark" "100"
+	config_get table_mask "infra" "table_mask" "0xff"
 	config_get tproxy_mark "infra" "tproxy_mark" "101"
 	config_get tun_mark "infra" "tun_mark" "102"
 	config_get tun_name "infra" "tun_name" "singtun0"
 
 	# Tproxy
-	ip rule del fwmark "$tproxy_mark"/0xff table "$table_mark" 2>"/dev/null"
+	ip rule del fwmark "$tproxy_mark"/"$table_mask" table "$table_mark" 2>"/dev/null"
 	ip route del local 0.0.0.0/0 dev lo table "$table_mark" 2>"/dev/null"
-	ip -6 rule del fwmark "$tproxy_mark"/0xff table "$table_mark" 2>"/dev/null"
+	ip -6 rule del fwmark "$tproxy_mark"/"$table_mask" table "$table_mark" 2>"/dev/null"
 	ip -6 route del local ::/0 dev lo table "$table_mark" 2>"/dev/null"
 
 	# TUN
 	ip route del default dev "$tun_name" table "$table_mark" 2>"/dev/null"
-	ip rule del fwmark "$tun_mark"/0xff table "$table_mark" 2>"/dev/null"
+	ip rule del fwmark "$tun_mark"/"$table_mask" table "$table_mark" 2>"/dev/null"
 
 	ip -6 route del default dev "$tun_name" table "$table_mark" 2>"/dev/null"
-	ip -6 rule del fwmark/0xff "$tun_mark" table "$table_mark" 2>"/dev/null"
+	ip -6 rule del fwmark "$tun_mark"/"$table_mask" table "$table_mark" 2>"/dev/null"
 
 	# Nftables rules
 	for i in "homeproxy_dstnat_redir" "homeproxy_output_redir" \

--- a/root/etc/init.d/homeproxy
+++ b/root/etc/init.d/homeproxy
@@ -124,11 +124,11 @@ start_service() {
 				local tproxy_mark
 				config_get tproxy_mark "infra" "tproxy_mark" "101"
 
-				ip rule add fwmark "$tproxy_mark" table "$table_mark"
+				ip rule add fwmark "$tproxy_mark"/0xff table "$table_mark"
 				ip route add local 0.0.0.0/0 dev lo table "$table_mark"
 
 				if [ "$ipv6_support" -eq "1" ]; then
-					ip -6 rule add fwmark "$tproxy_mark" table "$table_mark"
+					ip -6 rule add fwmark "$tproxy_mark"/0xff table "$table_mark"
 					ip -6 route add local ::/0 dev lo table "$table_mark"
 				fi
 			fi
@@ -143,10 +143,10 @@ start_service() {
 			ip link set "$tun_name" up
 
 			ip route replace default dev "$tun_name" table "$table_mark"
-			ip rule add fwmark "$tun_mark" lookup "$table_mark"
+			ip rule add fwmark "$tun_mark"/0xff lookup "$table_mark"
 
 			ip -6 route replace default dev "$tun_name" table "$table_mark"
-			ip -6 rule add fwmark "$tun_mark" lookup "$table_mark"
+			ip -6 rule add fwmark "$tun_mark"/0xff lookup "$table_mark"
 			;;
 		esac
 
@@ -310,17 +310,17 @@ stop_service() {
 	config_get tun_name "infra" "tun_name" "singtun0"
 
 	# Tproxy
-	ip rule del fwmark "$tproxy_mark" table "$table_mark" 2>"/dev/null"
+	ip rule del fwmark "$tproxy_mark"/0xff table "$table_mark" 2>"/dev/null"
 	ip route del local 0.0.0.0/0 dev lo table "$table_mark" 2>"/dev/null"
-	ip -6 rule del fwmark "$tproxy_mark" table "$table_mark" 2>"/dev/null"
+	ip -6 rule del fwmark "$tproxy_mark"/0xff table "$table_mark" 2>"/dev/null"
 	ip -6 route del local ::/0 dev lo table "$table_mark" 2>"/dev/null"
 
 	# TUN
 	ip route del default dev "$tun_name" table "$table_mark" 2>"/dev/null"
-	ip rule del fwmark "$tun_mark" table "$table_mark" 2>"/dev/null"
+	ip rule del fwmark "$tun_mark"/0xff table "$table_mark" 2>"/dev/null"
 
 	ip -6 route del default dev "$tun_name" table "$table_mark" 2>"/dev/null"
-	ip -6 rule del fwmark "$tun_mark" table "$table_mark" 2>"/dev/null"
+	ip -6 rule del fwmark/0xff "$tun_mark" table "$table_mark" 2>"/dev/null"
 
 	# Nftables rules
 	for i in "homeproxy_dstnat_redir" "homeproxy_output_redir" \


### PR DESCRIPTION
 It's possible to make homeproxy work together with mwan3 by using different mark locations. Both homeproxy and mwan3 use the fwmark field for packet marking, which can lead to conflicts if they use the same bits of the fwmark field. However, the fwmark field is 32 bits long, so there's plenty of room for both to use different bits.