### PR TITLE
Fix cron expressions being flushed after the homeproxy service is restarted.

### DIFF
--- a/root/etc/init.d/homeproxy
+++ b/root/etc/init.d/homeproxy
@@ -15,6 +15,8 @@ HP_DIR="/etc/homeproxy"
 RUN_DIR="/var/run/homeproxy"
 LOG_PATH="$RUN_DIR/homeproxy.log"
 
+UPDATE_CROND="update_crond.sh"
+
 # we don't know which is the default server, just take the first one
 DNSMASQ_UCI_CONFIG="$(uci -q show "dhcp.@dnsmasq[0]" | awk 'NR==1 {split($0, conf, /[.=]/); print conf[2]}')"
 if [ -f "/tmp/etc/dnsmasq.conf.$DNSMASQ_UCI_CONFIG" ]; then
@@ -304,7 +306,7 @@ start_service() {
 }
 
 stop_service() {
-	sed -i "/$CONF/d" "/etc/crontabs/root" 2>"/dev/null"
+	sed -i "/$UPDATE_CROND/d" "/etc/crontabs/root" 2>"/dev/null"
 	/etc/init.d/cron restart >"/dev/null" 2>&1
 
 	# Setup firewall

--- a/root/etc/init.d/homeproxy
+++ b/root/etc/init.d/homeproxy
@@ -15,8 +15,6 @@ HP_DIR="/etc/homeproxy"
 RUN_DIR="/var/run/homeproxy"
 LOG_PATH="$RUN_DIR/homeproxy.log"
 
-UPDATE_CROND="update_crond.sh"
-
 # we don't know which is the default server, just take the first one
 DNSMASQ_UCI_CONFIG="$(uci -q show "dhcp.@dnsmasq[0]" | awk 'NR==1 {split($0, conf, /[.=]/); print conf[2]}')"
 if [ -f "/tmp/etc/dnsmasq.conf.$DNSMASQ_UCI_CONFIG" ]; then
@@ -306,7 +304,7 @@ start_service() {
 }
 
 stop_service() {
-	sed -i "/$UPDATE_CROND/d" "/etc/crontabs/root" 2>"/dev/null"
+	sed -i "/update_crond.sh/d" "/etc/crontabs/root" 2>"/dev/null"
 	/etc/init.d/cron restart >"/dev/null" 2>&1
 
 	# Setup firewall


### PR DESCRIPTION
See [#161](https://github.com/immortalwrt/homeproxy/issues/161) .