### PR TITLE
Enhance hopping ports validation and parsing

### DIFF
--- a/htdocs/luci-static/resources/view/homeproxy/node.js
+++ b/htdocs/luci-static/resources/view/homeproxy/node.js
@@ -364,6 +364,37 @@ function parseShareLink(uri, features) {
 	return config;
 }
 
+function validateHoppingPorts(section_id, value) {
+	if (section_id && value) {
+		let ports = value.split(',').map(s => s.trim()).filter(s => s !== '');
+
+		for (let port of ports) {
+			if (/^\d+$/.test(port)) {
+				let portNum = parseInt(port);
+				if (portNum < 0 || portNum > 65535) {
+					return _('Expecting: %s').format( _('valid port range (port1:port2)'));
+				}
+				continue;
+			}
+
+			let match = port.match(/^(\d+):(\d+)$/);
+
+			if (!match) {
+				return _('Expecting: %s').format( _('valid port range (port1:port2)'));
+			}
+
+			let start = parseInt(match[1]);
+			let end = parseInt(match[2]);
+
+			if (start < 0 || start > 65535 || end < 0 || end > 65535 || start > end) {
+				return _('Expecting: %s').format( _('valid port range (port1:port2)'));
+			}
+		}
+	}
+
+	return true;
+}
+
 function renderNodeSettings(section, data, features, main_node, routing_mode) {
 	let s = section, o;
 	s.rowcolors = true;
@@ -479,7 +510,7 @@ function renderNodeSettings(section, data, features, main_node, routing_mode) {
 	o = s.option(form.DynamicList, 'hysteria_hopping_port', _('Hopping port'));
 	o.depends('type', 'hysteria');
 	o.depends('type', 'hysteria2');
-	o.validate = hp.validatePortRange;
+	o.validate = validateHoppingPorts;
 	o.modalonly = true;
 
 	o = s.option(form.Value, 'hysteria_hop_interval', _('Hop interval'),

--- a/root/etc/homeproxy/scripts/generate_client.uc
+++ b/root/etc/homeproxy/scripts/generate_client.uc
@@ -182,6 +182,12 @@ function generate_endpoint(node) {
 
 	return endpoint;
 }
+	
+function parse_hopping_ports(port_str) {
+    let ranges = filter(map(split(port_str, ","), s => trim(s)), s => s !== "");
+
+    return ranges.length === 1 ? ranges[0] : ranges;
+}
 
 function generate_outbound(node) {
 	if (type(node) !== 'object' || isEmpty(node))
@@ -195,7 +201,7 @@ function generate_outbound(node) {
 		server: node.address,
 		server_port: strToInt(node.port),
 		/* Hysteria(2) */
-		server_ports: node.hysteria_hopping_port,
+		server_ports: node.hysteria_hopping_port ? parse_hopping_ports(node.hysteria_hopping_port) : null,
 
 		username: (node.type !== 'ssh') ? node.username : null,
 		user: (node.type === 'ssh') ? node.username : null,


### PR DESCRIPTION
- **Added `validateHoppingPorts` function:**  
  - Validates port formats, supporting single ports (`0-65535`) and ranges (`port1:port2`).  
  - Filters out invalid inputs, such as negative values, ports exceeding `65535`, or ranges where `port1 > port2`.  
  - Returns `true` if validation passes; otherwise, returns an error message.  

- **Added `parse_hopping_ports` function:**  
  - Parses port lists, trims whitespace, and splits multiple ports or ranges using `,`.  
  - Supports only the `port1:port2` format and does not process `port1-port2`.  
  - Returns a string if there's a single entry; otherwise, returns an array.  
