### PR TITLE
fix(client): tuic disable utls

### DIFF
--- a/htdocs/luci-static/resources/view/homeproxy/node.js
+++ b/htdocs/luci-static/resources/view/homeproxy/node.js
@@ -1119,7 +1119,7 @@ function renderNodeSettings(section, data, features, main_node, routing_mode) {
 		o.value('random');
 		o.value('randomized');
 		o.value('safari');
-		o.depends({'tls': '1', 'type': /^((?!hysteria2?$).)+$/});
+		o.depends({'tls': '1', 'type': /^((?!hysteria2?|tuic$).)+$/});
 		o.validate = function(section_id, value) {
 			if (section_id) {
 				let tls_reality = this.map.findElement('id', 'cbid.homeproxy.%s.tls_reality'.format(section_id)).firstElementChild;


### PR DESCRIPTION
tuic and Hysteria2 are both based on QUIC and use UDP, not supporting TCP's utls
Close it to avoid accidental activation,activating it will cause the protocol to fail to connect