### PR TITLE
fix: incorrect config keys iteration when deleting obsolete node option

### DIFF
--- a/root/etc/homeproxy/scripts/update_subscriptions.uc
+++ b/root/etc/homeproxy/scripts/update_subscriptions.uc
@@ -569,7 +569,7 @@ function main() {
 
 			log(sprintf('Removing node: %s.', cfg.label || cfg['name']));
 		} else {
-			map(keys(node_cache[cfg.grouphash][cfg['.name']]), (v) => {
+			map(keys(cfg), (v) => {
 				if (v in node_cache[cfg.grouphash][cfg['.name']])
 					uci.set(uciconfig, cfg['.name'], v, node_cache[cfg.grouphash][cfg['.name']][v]);
 				else


### PR DESCRIPTION
I guess you want to remove unused keys in the config when updating nodes but it seems that you iterate the wrong object.