### PR TITLE
- Support Mihomo JSON-line subscriptions and fix Hysteria2 hopping port parsing

### DIFF
--- a/htdocs/luci-static/resources/view/homeproxy/node.js
+++ b/htdocs/luci-static/resources/view/homeproxy/node.js
@@ -19,6 +19,17 @@ function allowInsecureConfirm(ev, _section_id, value) {
 		ev.target.firstElementChild.checked = null;
 }
 
+function normalizeHysteriaHoppingPort(mport) {
+	if (!mport)
+		return null;
+
+	const ports = mport.split(',')
+		.map((p) => p.trim())
+		.filter((p) => p.length)
+		.map((p) => (/^\d+$/.test(p) ? `${p}:${p}` : p.replace('-', ':')));
+	return ports.length ? ports : null;
+}
+
 function parseShareLink(uri, features) {
 	let config, url, params;
 
@@ -75,6 +86,7 @@ function parseShareLink(uri, features) {
 				type: 'hysteria',
 				address: url.hostname,
 				port: url.port || '80',
+				hysteria_hopping_port: normalizeHysteriaHoppingPort(params.get('mport')),
 				hysteria_protocol: params.get('protocol') || 'udp',
 				hysteria_auth_type: params.get('auth') ? 'string' : null,
 				hysteria_auth_payload: params.get('auth'),
@@ -105,6 +117,7 @@ function parseShareLink(uri, features) {
 				password: url.username ? (
 					decodeURIComponent(url.username + (url.password ? (':' + url.password) : ''))
 				) : null,
+				hysteria_hopping_port: normalizeHysteriaHoppingPort(params.get('mport')),
 				hysteria_obfs_type: params.get('obfs'),
 				hysteria_obfs_password: params.get('obfs-password'),
 				tls: '1',

--- a/root/etc/homeproxy/scripts/update_subscriptions.uc
+++ b/root/etc/homeproxy/scripts/update_subscriptions.uc
@@ -80,10 +80,396 @@ function log(...args) {
 	logfile.close();
 }
 
+function has_value(value) {
+	return value !== null && value !== '' && value !== 'nil';
+}
+
+function to_string(value) {
+	return has_value(value) ? sprintf('%s', value) : null;
+}
+
+function bool_to_uci(value) {
+	if (value === true)
+		return '1';
+	if (value === false)
+		return '0';
+	return null;
+}
+
+function normalize_list(value) {
+	if (!has_value(value))
+		return null;
+	if (type(value) === 'array')
+		return value;
+	return [to_string(value)];
+}
+
+function normalize_host_list(value) {
+	if (!has_value(value))
+		return null;
+	if (type(value) === 'array')
+		return value;
+	return split(to_string(value), ',');
+}
+
+function normalize_first(value) {
+	if (!has_value(value))
+		return null;
+	if (type(value) === 'array')
+		return length(value) ? value[0] : null;
+	return to_string(value);
+}
+
+function normalize_hysteria_hopping_port(mport) {
+	if (!has_value(mport))
+		return null;
+
+	let ports = [];
+	for (let p in split(to_string(mport), ',')) {
+		p = trim(p);
+		if (!p)
+			continue;
+		if (match(p, /^\d+$/))
+			p = p + ':' + p;
+		else
+			p = replace(p, '-', ':');
+		push(ports, p);
+	}
+
+	return length(ports) ? ports : null;
+}
+
+function normalize_mihomo_ports(ports) {
+	if (!has_value(ports))
+		return null;
+
+	if (type(ports) === 'array')
+		return map(ports, (p) => {
+			const v = to_string(p);
+			if (match(v, /^\d+$/))
+				return v + ':' + v;
+			return replace(v, '-', ':');
+		});
+
+	return normalize_hysteria_hopping_port(to_string(ports));
+}
+
+function parse_mihomo_speed(value) {
+	if (!has_value(value))
+		return null;
+
+	const str = to_string(value);
+	const match_val = match(str, /[0-9]+(\.[0-9]+)?/);
+	if (!match_val)
+		return null;
+
+	const num_str = type(match_val) === 'array' ? match_val[0] : match_val;
+	if (!num_str)
+		return null;
+
+	const num = int(num_str);
+	if (num === null || num != num)
+		return null;
+
+	return to_string(num);
+}
+
+function get_header_host(headers) {
+	if (type(headers) !== 'object')
+		return null;
+
+	return headers.Host || headers.host || headers['HOST'];
+}
+
+function apply_transport_opts(config, proxy) {
+	const network = proxy.network;
+	if (!has_value(network) || network === 'tcp')
+		return;
+
+	let ws_opts = proxy['ws-opts'] || {};
+	let grpc_opts = proxy['grpc-opts'] || {};
+	let http_opts = proxy['http-opts'] || proxy['h2-opts'] || {};
+	let httpupgrade_opts = proxy['http-upgrade-opts'] || {};
+
+	switch (network) {
+	case 'ws':
+		config.transport = 'ws';
+		config.ws_path = ws_opts.path ? to_string(ws_opts.path) : null;
+		config.ws_host = get_header_host(ws_opts.headers);
+		config.websocket_early_data = ws_opts['early-data'] ? to_string(ws_opts['early-data']) : null;
+		config.websocket_early_data_header = ws_opts['early-data-header-name'] ?
+			to_string(ws_opts['early-data-header-name']) : null;
+		break;
+	case 'grpc':
+		config.transport = 'grpc';
+		config.grpc_servicename = to_string(grpc_opts['grpc-service-name'] || grpc_opts['service-name']);
+		break;
+	case 'http':
+	case 'h2':
+		config.transport = 'http';
+		config.http_path = normalize_first(http_opts.path);
+		config.http_host = normalize_host_list(get_header_host(http_opts.headers) || http_opts.host);
+		break;
+	case 'httpupgrade':
+		config.transport = 'httpupgrade';
+		config.httpupgrade_host = get_header_host(httpupgrade_opts.headers) || httpupgrade_opts.host;
+		config.http_path = normalize_first(httpupgrade_opts.path);
+		break;
+	}
+}
+
+function parse_mihomo_proxy(proxy) {
+	if (type(proxy) !== 'object')
+		return null;
+
+	let config;
+	const tls_sni = proxy.servername || proxy.sni;
+	const tls_fingerprint = proxy['client-fingerprint'] || proxy.fingerprint;
+
+	switch (proxy.type) {
+	case 'vmess':
+		config = {
+			label: proxy.name,
+			type: 'vmess',
+			address: proxy.server,
+			port: to_string(proxy.port),
+			uuid: proxy.uuid,
+			vmess_alterid: has_value(proxy.alterId) ? to_string(proxy.alterId) : null,
+			vmess_encrypt: proxy.cipher,
+			packet_encoding: proxy['packet-encoding'],
+			tls: (proxy.tls === true) ? '1' : '0',
+			tls_sni,
+			tls_alpn: normalize_list(proxy.alpn),
+			tls_insecure: bool_to_uci(proxy['skip-cert-verify']),
+			tls_utls: sing_features.with_utls ? tls_fingerprint : null,
+			tcp_fast_open: (proxy.tfo === true) ? '1' : null
+		};
+		apply_transport_opts(config, proxy);
+		break;
+	case 'hysteria2':
+		if (!sing_features.with_quic) {
+			log(sprintf('Skipping unsupported %s node: %s.', proxy.type, proxy.name || proxy.server));
+			log(sprintf('Please rebuild sing-box with %s support!', 'QUIC'));
+			return null;
+		}
+		config = {
+			label: proxy.name,
+			type: 'hysteria2',
+			address: proxy.server,
+			port: to_string(proxy.port),
+			password: proxy.password,
+			hysteria_hopping_port: normalize_mihomo_ports(proxy.ports),
+			hysteria_down_mbps: parse_mihomo_speed(proxy.down),
+			hysteria_up_mbps: parse_mihomo_speed(proxy.up),
+			hysteria_obfs_type: proxy.obfs,
+			hysteria_obfs_password: proxy['obfs-password'],
+			tls: '1',
+			tls_sni,
+			tls_alpn: normalize_list(proxy.alpn),
+			tls_insecure: bool_to_uci(proxy['skip-cert-verify']),
+			tcp_fast_open: (proxy.tfo === true) ? '1' : null
+		};
+		break;
+	case 'hysteria':
+		if (!sing_features.with_quic) {
+			log(sprintf('Skipping unsupported %s node: %s.', proxy.type, proxy.name || proxy.server));
+			log(sprintf('Please rebuild sing-box with %s support!', 'QUIC'));
+			return null;
+		}
+		config = {
+			label: proxy.name,
+			type: 'hysteria',
+			address: proxy.server,
+			port: to_string(proxy.port),
+			hysteria_hopping_port: normalize_mihomo_ports(proxy.ports),
+			hysteria_protocol: proxy.protocol,
+			hysteria_auth_type: proxy['auth-str'] ? 'string' : (proxy.auth ? 'base64' : null),
+			hysteria_auth_payload: proxy['auth-str'] || proxy.auth,
+			hysteria_obfs_password: proxy.obfs,
+			hysteria_down_mbps: parse_mihomo_speed(proxy.down),
+			hysteria_up_mbps: parse_mihomo_speed(proxy.up),
+			tls: '1',
+			tls_sni,
+			tls_alpn: normalize_list(proxy.alpn),
+			tls_insecure: bool_to_uci(proxy['skip-cert-verify']),
+			tcp_fast_open: (proxy.tfo === true) ? '1' : null
+		};
+		break;
+	case 'vless':
+		config = {
+			label: proxy.name,
+			type: 'vless',
+			address: proxy.server,
+			port: to_string(proxy.port),
+			uuid: proxy.uuid,
+			vless_flow: proxy.flow,
+			packet_encoding: proxy['packet-encoding'],
+			tls: (proxy.tls === true || proxy['reality-opts']) ? '1' : '0',
+			tls_sni,
+			tls_insecure: bool_to_uci(proxy['skip-cert-verify']),
+			tls_utls: sing_features.with_utls ? tls_fingerprint : null,
+			tls_reality: proxy['reality-opts'] ? '1' : '0',
+			tls_reality_public_key: proxy['reality-opts'] ? proxy['reality-opts']['public-key'] : null,
+			tls_reality_short_id: proxy['reality-opts'] ? proxy['reality-opts']['short-id'] : null,
+			tcp_fast_open: (proxy.tfo === true) ? '1' : null
+		};
+		apply_transport_opts(config, proxy);
+		break;
+	case 'trojan':
+		config = {
+			label: proxy.name,
+			type: 'trojan',
+			address: proxy.server,
+			port: to_string(proxy.port),
+			password: proxy.password,
+			tls: (proxy.tls === false) ? '0' : '1',
+			tls_sni,
+			tls_alpn: normalize_list(proxy.alpn),
+			tls_insecure: bool_to_uci(proxy['skip-cert-verify']),
+			tls_utls: sing_features.with_utls ? tls_fingerprint : null,
+			tcp_fast_open: (proxy.tfo === true) ? '1' : null
+		};
+		apply_transport_opts(config, proxy);
+		break;
+	case 'ss': {
+		let ss_plugin = proxy.plugin;
+		if (ss_plugin === 'simple-obfs')
+			ss_plugin = 'obfs-local';
+		config = {
+			label: proxy.name,
+			type: 'shadowsocks',
+			address: proxy.server,
+			port: to_string(proxy.port),
+			shadowsocks_encrypt_method: proxy.cipher,
+			password: proxy.password,
+			shadowsocks_plugin: ss_plugin,
+			shadowsocks_plugin_opts: proxy['plugin-opts'],
+			udp_over_tcp: bool_to_uci(proxy['udp-over-tcp']),
+			udp_over_tcp_version: to_string(proxy['udp-over-tcp-version']),
+			tcp_fast_open: (proxy.tfo === true) ? '1' : null
+		};
+		break;
+	}
+	case 'ssr':
+		log(sprintf('Skipping unsupported ssr node: %s.', proxy.name || proxy.server));
+		return null;
+	case 'socks5':
+	case 'socks':
+	case 'socks4':
+	case 'socks4a':
+		config = {
+			label: proxy.name,
+			type: 'socks',
+			address: proxy.server,
+			port: to_string(proxy.port),
+			username: proxy.username,
+			password: proxy.password,
+			socks_version: (proxy.type === 'socks4a') ? '4a' : ((proxy.type === 'socks4') ? '4' : '5'),
+			tls: (proxy.tls === true) ? '1' : '0',
+			tls_sni,
+			tls_insecure: bool_to_uci(proxy['skip-cert-verify']),
+			tls_utls: sing_features.with_utls ? tls_fingerprint : null,
+			tcp_fast_open: (proxy.tfo === true) ? '1' : null
+		};
+		break;
+	case 'http':
+		config = {
+			label: proxy.name,
+			type: 'http',
+			address: proxy.server,
+			port: to_string(proxy.port),
+			username: proxy.username,
+			password: proxy.password,
+			tls: (proxy.tls === true) ? '1' : '0',
+			tls_sni,
+			tls_insecure: bool_to_uci(proxy['skip-cert-verify']),
+			tls_utls: sing_features.with_utls ? tls_fingerprint : null,
+			tcp_fast_open: (proxy.tfo === true) ? '1' : null
+		};
+		break;
+	case 'tuic': {
+		if (!sing_features.with_quic) {
+			log(sprintf('Skipping unsupported %s node: %s.', proxy.type, proxy.name || proxy.server));
+			log(sprintf('Please rebuild sing-box with %s support!', 'QUIC'));
+			return null;
+		}
+		let tuic_heartbeat = proxy['heartbeat-interval'];
+		if (has_value(tuic_heartbeat)) {
+			tuic_heartbeat = int(tuic_heartbeat);
+			if (tuic_heartbeat >= 1000)
+				tuic_heartbeat = int(tuic_heartbeat / 1000);
+		}
+		config = {
+			label: proxy.name,
+			type: 'tuic',
+			address: proxy.server,
+			port: to_string(proxy.port),
+			uuid: proxy.uuid,
+			password: proxy.password || proxy.token,
+			tuic_congestion_control: proxy['congestion-controller'],
+			tuic_udp_relay_mode: proxy['udp-relay-mode'],
+			tuic_udp_over_stream: bool_to_uci(proxy['udp-over-stream']),
+			tuic_enable_zero_rtt: bool_to_uci(proxy['zero-rtt-handshake']),
+			tuic_heartbeat: has_value(tuic_heartbeat) ? to_string(tuic_heartbeat) : null,
+			tls: '1',
+			tls_sni: proxy['disable-sni'] ? null : tls_sni,
+			tls_alpn: normalize_list(proxy.alpn),
+			tls_insecure: bool_to_uci(proxy['skip-cert-verify']),
+			tcp_fast_open: (proxy.tfo === true) ? '1' : null
+		};
+		break;
+	}
+	case 'ssh':
+		config = {
+			label: proxy.name,
+			type: 'ssh',
+			address: proxy.server,
+			port: to_string(proxy.port),
+			username: proxy.username,
+			password: proxy.password,
+			ssh_client_version: proxy['client-version'],
+			ssh_host_key: normalize_list(proxy['host-key']),
+			ssh_host_key_algo: normalize_list(proxy['host-key-algorithms']),
+			ssh_priv_key: normalize_list(proxy['private-key']),
+			ssh_priv_key_pp: proxy['private-key-passphrase'],
+			tcp_fast_open: (proxy.tfo === true) ? '1' : null
+		};
+		break;
+	case 'wireguard': {
+		let wg_addresses = [];
+		if (has_value(proxy.ip))
+			push(wg_addresses, to_string(proxy.ip));
+		if (has_value(proxy.ipv6))
+			push(wg_addresses, to_string(proxy.ipv6));
+		config = {
+			label: proxy.name,
+			type: 'wireguard',
+			address: proxy.server,
+			port: to_string(proxy.port),
+			wireguard_local_address: length(wg_addresses) ? wg_addresses : null,
+			wireguard_private_key: proxy['private-key'],
+			wireguard_peer_public_key: proxy['public-key'],
+			wireguard_pre_shared_key: proxy['pre-shared-key'],
+			wireguard_reserved: normalize_list(proxy.reserved),
+			wireguard_mtu: to_string(proxy.mtu),
+			wireguard_persistent_keepalive_interval: to_string(proxy['persistent-keepalive'] || proxy['persistent-keepalive-interval'] || proxy.keepalive)
+		};
+		break;
+	}
+	default:
+		return null;
+	}
+
+	return config;
+}
+
 function parse_uri(uri) {
 	let config, url, params;
 
 	if (type(uri) === 'object') {
+		if (uri.nodetype === 'mihomo') {
+			return parse_mihomo_proxy(uri);
+		}
 		if (uri.nodetype === 'sip008') {
 			/* https://shadowsocks.org/guide/sip008.html */
 			config = {
@@ -151,6 +537,7 @@ function parse_uri(uri) {
 				type: 'hysteria',
 				address: url.hostname,
 				port: url.port,
+				hysteria_hopping_port: normalize_hysteria_hopping_port(params.mport),
 				hysteria_protocol: params.protocol || 'udp',
 				hysteria_auth_type: params.auth ? 'string' : null,
 				hysteria_auth_payload: params.auth,
@@ -184,6 +571,7 @@ function parse_uri(uri) {
 				password: url.username ? (
 					urldecode(url.username + (url.password ? (':' + url.password) : ''))
 				) : null,
+				hysteria_hopping_port: normalize_hysteria_hopping_port(params.mport),
 				hysteria_obfs_type: params.obfs,
 				hysteria_obfs_password: params['obfs-password'],
 				tls: '1',
@@ -473,6 +861,46 @@ function parse_uri(uri) {
 	return config;
 }
 
+function parse_mihomo_yaml(text) {
+	if (isEmpty(text) || type(text) !== 'string')
+		return null;
+
+	let in_proxies = false;
+	let proxies = [];
+	for (let line in split(text, '\n')) {
+		line = trim(line);
+		if (line === 'proxies:' || match(line, /^proxies:\s*$/)) {
+			in_proxies = true;
+			continue;
+		}
+		if (!in_proxies)
+			continue;
+
+		if (!line)
+			continue;
+
+		if (match(line, /^\w+:\s*$/) && line !== '-')
+			break;
+
+		const m = match(line, /^-\s*(\{.*\})\s*$/);
+		if (!m)
+			continue;
+
+		let obj;
+		try {
+			obj = json(m[1]);
+		} catch(e) {
+			obj = null;
+		}
+		if (obj) {
+			obj.nodetype = 'mihomo';
+			push(proxies, obj);
+		}
+	}
+
+	return length(proxies) ? proxies : null;
+}
+
 function main() {
 	if (via_proxy !== '1') {
 		log('Stopping service...');
@@ -498,8 +926,15 @@ function main() {
 			if (nodes[0].server && nodes[0].method)
 				map(nodes, (_, i) => nodes[i].nodetype = 'sip008');
 		} catch(e) {
-			nodes = decodeBase64Str(res);
-			nodes = nodes ? split(trim(replace(nodes, / /g, '_')), '\n') : [];
+			nodes = parse_mihomo_yaml(res);
+			if (isEmpty(nodes)) {
+				nodes = decodeBase64Str(res);
+				const decoded_nodes = parse_mihomo_yaml(nodes);
+				if (!isEmpty(decoded_nodes))
+					nodes = decoded_nodes;
+				else
+					nodes = nodes ? split(trim(replace(nodes, / /g, '_')), '\n') : [];
+			}
 		}
 
 		let count = 0;
@@ -523,7 +958,7 @@ function main() {
 			else {
 				if (config.tls === '1' && allow_insecure === '1')
 					config.tls_insecure = '1';
-				if (config.type in ['vless', 'vmess'])
+				if (config.type in ['vless', 'vmess'] && isEmpty(config.packet_encoding))
 					config.packet_encoding = packet_encoding;
 
 				config.grouphash = groupHash;


### PR DESCRIPTION
What changed

  - Added support for Mihomo proxies: JSON-line subscription format so fields can be fully imported (including hopping ports and up/down
    limits).
  - Fixed Hysteria2 hopping port parsing from both Mihomo subscriptions and share links.
  - Avoided null is not iterable errors when urltest_nodes is empty by normalizing list inputs.

  Why

  - The new Mihomo format was not fully imported, causing missing hopping ports and speed limits.
  - Hysteria2 ports/mport values were not mapped correctly, so port hopping didn’t take effect.
  - Empty urltest node lists caused runtime errors during client config generation.

  Testing

  - Manually updated subscriptions using Mihomo JSON-line proxies input.
  - Verified Hysteria2 hopping ports and up/down limits populate correctly (or remain empty if invalid).
  - Generated client config without null is not iterable errors.

  Files changed

  - htdocs/luci-static/resources/view/homeproxy/node.js
  - root/etc/homeproxy/scripts/update_subscriptions.uc
  - root/etc/homeproxy/scripts/generate_client.uc