### PR TITLE
fix(generator/client): append unit to gRPC/HTTP2 transport timeouts

### DIFF
--- a/root/etc/homeproxy/scripts/generate_client.uc
+++ b/root/etc/homeproxy/scripts/generate_client.uc
@@ -327,8 +327,8 @@ function generate_outbound(node) {
 			max_early_data: strToInt(node.websocket_early_data),
 			early_data_header_name: node.websocket_early_data_header,
 			service_name: node.grpc_servicename,
-			idle_timeout: (node.http_idle_timeout),
-			ping_timeout: (node.http_ping_timeout),
+			idle_timeout: strToTime(node.http_idle_timeout),
+			ping_timeout: strToTime(node.http_ping_timeout),
 			permit_without_stream: strToBool(node.grpc_permit_without_stream)
 		} : null,
 		udp_over_tcp: (node.udp_over_tcp === '1') ? {


### PR DESCRIPTION
## Summary

- `idle_timeout` and `ping_timeout` on outbound transport (gRPC / HTTP2+TLS) were emitted as bare numeric strings (e.g. `"15"`), but sing-box parses them as Go `time.Duration` and rejects values without a unit suffix.
- The server-side generator (`generate_server.uc:175-176`) and the URLTest generator (`generate_client.uc:819`) already wrap the same UCI values in `strToTime()`; this aligns the client outbound transport to behave the same way.

Before: `"idle_timeout": "15"` → sing-box parse error / field dropped.
After: `"idle_timeout": "15s"` — matches the sing-box [v2ray-transport docs](https://sing-box.sagernet.org/configuration/shared/v2ray-transport/).

## Test plan

- [ ] Configure a gRPC or HTTP2+TLS outbound with the *Idle timeout* / *Ping timeout* fields set in LuCI.
- [ ] Verify the generated `/var/run/homeproxy/sing-box-c.json` contains `"idle_timeout": "<N>s"` / `"ping_timeout": "<N>s"` rather than bare numbers.
- [ ] Confirm sing-box starts cleanly with the generated config.