### PR TITLE
Fix for an issue when deleted node exist in URLTest crashes sing-box

### DIFF
--- a/root/etc/homeproxy/scripts/generate_client.uc
+++ b/root/etc/homeproxy/scripts/generate_client.uc
@@ -721,6 +721,8 @@ if (!isEmpty(main_node)) {
 
 	for (let i in urltest_nodes) {
 		const urltest_node = uci.get_all(uciconfig, i) || {};
+		if (isEmpty(urltest_node))
+			continue;
 		if (urltest_node.type === 'wireguard') {
 			push(config.endpoints, generate_endpoint(urltest_node));
 			config.endpoints[length(config.endpoints)-1].tag = 'cfg-' + i + '-out';
@@ -776,6 +778,8 @@ if (!isEmpty(main_node)) {
 
 	for (let i in filter(urltest_nodes, (l) => !~index(routing_nodes, l))) {
 		const urltest_node = uci.get_all(uciconfig, i) || {};
+		if (isEmpty(urltest_node))
+			continue;
 		if (urltest_node.type === 'wireguard')
 			push(config.endpoints, generate_endpoint(urltest_node));
 		else


### PR DESCRIPTION
Fix for an issue when node deleted from UCI but still persist in URLTest, `uci.get_all() returns null (coerced to {} by || {}). generate_outbound({}) / generate_endpoint({}) return null`, which is pushed onto the outbounds/endpoints array and thus crashed sing-box. Added isEmpty to skip the missing node. It is problematic as Proxy services could replace provided servers.