### PR TITLE
fix(build): use 'noarch' instead of 'all' for APK arch field

### DIFF
--- a/.github/build-ipk.sh
+++ b/.github/build-ipk.sh
@@ -98,7 +98,7 @@ default_prerm' > "$TEMP_DIR/pre-deinstall"
 		--info "name:$PKG_NAME" \
 		--info "version:$PKG_VERSION" \
 		--info "description:The modern ImmortalWrt proxy platform for ARM64/AMD64" \
-		--info "arch:all" \
+		--info "arch:noarch" \
 		--info "origin:https://github.com/immortalwrt/homeproxy" \
 		--info "url:" \
 		--info "maintainer:Tianling Shen <cnsztl@immortalwrt.org>" \


### PR DESCRIPTION
fix apk CI build, the package can not been installed with arch:all on 25.12, while arch:noarch is correct.