### PR TITLE
Fix error: access to undeclared variable validation

### DIFF
--- a/root/etc/homeproxy/scripts/migrate_config.uc
+++ b/root/etc/homeproxy/scripts/migrate_config.uc
@@ -100,7 +100,7 @@ const dns_server_migration = {};
 uci.foreach(uciconfig, ucidnsserver, (cfg) => {
 	/* legacy format was deprecated in sb 1.12 */
 	if (cfg.address) {
-		const addr = parseURL((!match(cfg.address, /:\/\//) ? 'udp://' : '') + (validation('ip6addr', cfg.address) ? `[${cfg.address}]` : cfg.address));
+		const addr = parseURL((!match(cfg.address, /:\/\//) ? 'udp://' : '') + (match(cfg.address, /^[0-9a-fA-F:]+$/) && match(cfg.address, /:/) ? `[${cfg.address}]` : cfg.address));
 		/* RCode was moved into DNS rules */
 		if (addr.protocol === 'rcode') {
 			dns_server_migration[cfg['.name']] = { action: 'predefined' };


### PR DESCRIPTION
The script calls `validation('ip6addr', cfg.address)` to determine whether the address is an IPv6 address; however, the `validation` function is not imported at the top of the file, nor is it a built-in `ucode` function. Consequently, a "Reference error: access to undeclared variable validation" is triggered, seem like:
```
* Reference error: access to undeclared variable validation
  * In [arrow function](), file /etc/homeproxy/scripts/migrate_config.uc, line 103, byte 75:
  *   called from function foreach ([C])
  *   called from anonymous function (/etc/homeproxy/scripts/migrate_config.uc:155:2)
  * 
  *  `        const addr = parseURL((!match(cfg.address, /:\/\//) ? 'udp://' : '') + (validation('ip6addr', cfg.address) ? `[${cfg.address}]` : cfg.address));`
  *   Near here ----------------------------------------------------------------------^
  * 
  *
```