### PR TITLE
fix(client): make ACL domain lists take effect reliably

### DIFF
--- a/htdocs/luci-static/resources/view/homeproxy/client.js
+++ b/htdocs/luci-static/resources/view/homeproxy/client.js
@@ -1492,12 +1492,15 @@ return view.extend({
 			}, {});
 		}
 		so.write = function(_section_id, value) {
+			uci.set('homeproxy', 'control', 'proxy_domain_list_checksum', hp.calcStringMD5(value || ''));
 			return callWriteDomainList('proxy_list', value);
 		}
 		so.remove = function(/* ... */) {
 			let routing_mode = this.section.formvalue('config', 'routing_mode');
-			if (routing_mode !== 'custom')
+			if (routing_mode !== 'custom') {
+				uci.set('homeproxy', 'control', 'proxy_domain_list_checksum', hp.calcStringMD5(''));
 				return callWriteDomainList('proxy_list', '');
+			}
 			return true;
 		}
 		so.validate = function(section_id, value) {
@@ -1524,12 +1527,15 @@ return view.extend({
 			}, {});
 		}
 		so.write = function(_section_id, value) {
+			uci.set('homeproxy', 'control', 'direct_domain_list_checksum', hp.calcStringMD5(value || ''));
 			return callWriteDomainList('direct_list', value);
 		}
 		so.remove = function(/* ... */) {
 			let routing_mode = this.section.formvalue('config', 'routing_mode');
-			if (routing_mode !== 'custom')
+			if (routing_mode !== 'custom') {
+				uci.set('homeproxy', 'control', 'direct_domain_list_checksum', hp.calcStringMD5(''));
 				return callWriteDomainList('direct_list', '');
+			}
 			return true;
 		}
 		so.validate = function(section_id, value) {

--- a/root/etc/homeproxy/scripts/generate_client.uc
+++ b/root/etc/homeproxy/scripts/generate_client.uc
@@ -833,6 +833,14 @@ if (!isEmpty(main_node)) {
 			outbound: 'main-udp-out'
 		});
 
+	/* Proxy list */
+	if (length(proxy_domain_list))
+		push(config.route.rules, {
+			rule_set: 'proxy-domain',
+			action: 'route',
+			outbound: 'main-out'
+		});
+
 	config.route.final = 'main-out';
 
 	/* Rule set */

--- a/root/etc/init.d/homeproxy
+++ b/root/etc/init.d/homeproxy
@@ -104,6 +104,12 @@ start_service() {
 			sed -r -e '/^\s*$/d' -e "s/(.*)/server=\/\1\/127.0.0.1#$dns_port\nnftset=\/\1\\/4#inet#fw4#homeproxy_wan_proxy_addr_v4$wan_nftset_v6/g" \
 				"$HP_DIR/resources/proxy_list.txt" > "$DNSMASQ_DIR/proxy_list.conf"
 		fi
+		if [ "$routing_mode" != "custom" ] && [ -s "$HP_DIR/resources/direct_list.txt" ]; then
+			local wan_nftset_v6
+			[ "$ipv6_support" -eq "0" ] || wan_nftset_v6=",6#inet#fw4#homeproxy_wan_direct_addr_v6"
+			sed -r -e '/^\s*$/d' -e "s/(.*)/server=\/\1\/127.0.0.1#$dns_port\nnftset=\/\1\\/4#inet#fw4#homeproxy_wan_direct_addr_v4$wan_nftset_v6/g" \
+				"$HP_DIR/resources/direct_list.txt" > "$DNSMASQ_DIR/direct_list.conf"
+		fi
 		/etc/init.d/dnsmasq restart >"/dev/null" 2>&1
 
 		# Setup routing table


### PR DESCRIPTION
## Summary

Fix ACL domain list changes not reliably taking effect in client mode.

This updates the proxy/direct domain list handling so that:

- LuCI detects proxy/direct domain list-only edits and triggers Apply/Restart.
- Proxy domain list rules are actually added to sing-box route rules.
- Direct domain list entries populate the WAN direct nft set through dnsmasq, matching the existing proxy list behavior.

## Root Cause

The proxy/direct domain lists are stored in files under `/etc/homeproxy/resources/`, not directly as UCI list values. When only those files changed, LuCI could write the new content but still not mark the HomeProxy config as changed, so Apply/Restart was not triggered.

There were also two runtime gaps:

- `proxy-domain` rule sets could be generated without a matching route rule.
- `direct_list.txt` generated sing-box domain rules, but did not generate dnsmasq `nftset=` rules, so transparent routing could still only see the resolved IP and fall through to mode defaults.

## Changes

- Store checksums for proxy/direct domain list content in UCI so LuCI detects ACL-only edits.
- Add a route rule for `proxy-domain` to `main-out`.
- Generate dnsmasq `nftset=` rules for `direct_list.txt` to populate:
  - `homeproxy_wan_direct_addr_v4`
  - `homeproxy_wan_direct_addr_v6` when IPv6 is enabled

## Validation

Tested on ImmortalWrt with `bypass_mainland_china` and `redirect_tproxy` mode.

Verified that:

- ACL domain list edits trigger Apply/Restart.
- Direct domains resolve through the configured direct DNS path.
- Resolved direct-domain IPs are added to `homeproxy_wan_direct_addr_v4`.
- Traffic to those IPs returns/directs before default proxy routing.
- Proxy-domain DNS still resolves through `main-dns` via `main-out`.

Local checks:

```sh
sh -n root/etc/init.d/homeproxy
node --check htdocs/luci-static/resources/view/homeproxy/client.js
git diff --check origin/dev...HEAD
```
