### PR TITLE
homeproxy: fix stale chain name in stop cleanup and make routing rule setup idempotent

### DIFF
--- a/root/etc/init.d/homeproxy
+++ b/root/etc/init.d/homeproxy
@@ -117,12 +117,14 @@ start_service() {
 				local tproxy_mark
 				config_get tproxy_mark "infra" "tproxy_mark" "101"
 
+				ip rule del fwmark "$tproxy_mark" table "$table_mark" 2>"/dev/null"
 				ip rule add fwmark "$tproxy_mark" table "$table_mark"
-				ip route add local 0.0.0.0/0 dev lo table "$table_mark"
+				ip route replace local 0.0.0.0/0 dev lo table "$table_mark"
 
 				if [ "$ipv6_support" -eq "1" ]; then
+					ip -6 rule del fwmark "$tproxy_mark" table "$table_mark" 2>"/dev/null"
 					ip -6 rule add fwmark "$tproxy_mark" table "$table_mark"
-					ip -6 route add local ::/0 dev lo table "$table_mark"
+					ip -6 route replace local ::/0 dev lo table "$table_mark"
 				fi
 			fi
 			;;
@@ -136,9 +138,11 @@ start_service() {
 			ip link set "$tun_name" up
 
 			ip route replace default dev "$tun_name" table "$table_mark"
+			ip rule del fwmark "$tun_mark" lookup "$table_mark" 2>"/dev/null"
 			ip rule add fwmark "$tun_mark" lookup "$table_mark"
 
 			ip -6 route replace default dev "$tun_name" table "$table_mark"
+			ip -6 rule del fwmark "$tun_mark" lookup "$table_mark" 2>"/dev/null"
 			ip -6 rule add fwmark "$tun_mark" lookup "$table_mark"
 			;;
 		esac
@@ -285,7 +289,7 @@ stop_service() {
 		 "homeproxy_redirect_proxy_port" "homeproxy_redirect_lanac" \
 		 "homeproxy_mangle_prerouting" "homeproxy_mangle_output" \
 		 "homeproxy_mangle_tproxy" "homeproxy_mangle_tproxy_port" \
-		 "homeproxy_mangle_tproxy_lanac" "homeproxy_mangle_mark" \
+		 "homeproxy_mangle_lanac" "homeproxy_mangle_mark" \
 		 "homeproxy_mangle_tun" "homeproxy_mangle_tun_mark"; do
 		nft flush chain inet fw4 "$i"
 		nft delete chain inet fw4 "$i"


### PR DESCRIPTION
### Bug 1: stale chain name in `stop_service()` cleanup

The nftables cleanup list in `stop_service()` references `homeproxy_mangle_tproxy_lanac`,
but the chain actually created by `firewall_post.ut` is named `homeproxy_mangle_lanac`.
The stale name has no effect, while the real chain is never flushed/deleted by name
(it is currently only removed as a side effect of the full `fw4 reload`).

### Bug 2: non-idempotent policy routing setup in `start_service()`

`start_service()` adds `ip rule` / `ip -6 rule` entries unconditionally. If the service
starts without a clean prior stop (crash, unclean reload, double start), duplicate
`fwmark ... lookup` policy rules accumulate:

    0:      from all fwmark 0x65 lookup 100
    32764:  from all fwmark 0x65 lookup 100    <-- duplicate
    32765:  from all fwmark 0x65 lookup 100

This patch deletes any stale rule before adding it, and switches the `local` routes to
`ip route replace`, making the setup idempotent. Observed and verified on a live
OpenWrt 23.05 device (tproxy mode, IPv6 enabled).