### PR TITLE
homeproxy: drop legacy inbound sniff options removed in sing-box 1.12

### DIFF
--- a/root/etc/homeproxy/scripts/generate_client.uc
+++ b/root/etc/homeproxy/scripts/generate_client.uc
@@ -606,8 +606,6 @@ push(config.inbounds, {
 	listen: '::',
 	listen_port: int(mixed_port),
 	udp_timeout: strToTime(udp_timeout),
-	sniff: true,
-	sniff_override_destination: strToBool(sniff_override),
 	set_system_proxy: false
 });
 
@@ -617,9 +615,7 @@ if (match(proxy_mode, /redirect/))
 		tag: 'redirect-in',
 
 		listen: '::',
-		listen_port: int(redirect_port),
-		sniff: true,
-		sniff_override_destination: strToBool(sniff_override)
+		listen_port: int(redirect_port)
 	});
 if (match(proxy_mode, /tproxy/))
 	push(config.inbounds, {
@@ -629,9 +625,7 @@ if (match(proxy_mode, /tproxy/))
 		listen: '::',
 		listen_port: int(tproxy_port),
 		network: 'udp',
-		udp_timeout: strToTime(udp_timeout),
-		sniff: true,
-		sniff_override_destination: strToBool(sniff_override)
+		udp_timeout: strToTime(udp_timeout)
 	});
 if (match(proxy_mode, /tun/))
 	push(config.inbounds, {
@@ -644,9 +638,7 @@ if (match(proxy_mode, /tun/))
 		auto_route: false,
 		endpoint_independent_nat: strToBool(endpoint_independent_nat),
 		udp_timeout: strToTime(udp_timeout),
-		stack: tcpip_stack,
-		sniff: true,
-		sniff_override_destination: strToBool(sniff_override)
+		stack: tcpip_stack
 	});
 /* Inbound end */
 


### PR DESCRIPTION
### Problem

The client config generator still emits the inbound-level `sniff` and
`sniff_override_destination` options on the mixed / redirect / tproxy / tun
inbounds. These options were deprecated in sing-box 1.11 and removed in
sing-box 1.12, so generated configurations fail `sing-box check` with
"unknown field" errors on current sing-box releases, preventing the service
from starting.

### Fix

Remove the legacy inbound options from all four inbounds. Sniffing is now
handled by the route-level `sniff` action, which is intentionally left
commented in the routing rules per the existing note in the code
("leave for sing-box 1.13.0").

### Testing

Verified on a live OpenWrt 23.05 device (GL.iNet GL-BE3600, tproxy mode,
IPv6 enabled) running sing-box 1.13.14: `sing-box check` passes and the
generated client configuration runs correctly.