### PR TITLE
fix(ucode): replace removed init_action

### DIFF
--- a/root/etc/homeproxy/scripts/update_subscriptions.uc
+++ b/root/etc/homeproxy/scripts/update_subscriptions.uc
@@ -13,7 +13,6 @@ import { connect } from 'ubus';
 import { cursor } from 'uci';
 
 import { urldecode, urlencode } from 'luci.http';
-import { init_action } from 'luci.sys';
 
 import {
 	wGET, decodeBase64Str, getTime, isEmpty, parseURL,
@@ -78,6 +77,10 @@ function log(...args) {
 	const logfile = open(`${RUN_DIR}/homeproxy.log`, 'a');
 	logfile.write(`${getTime()} [SUBSCRIBE] ${join(' ', args)}\n`);
 	logfile.close();
+}
+
+function service_action(action) {
+	return system([ '/etc/init.d/homeproxy', action ]);
 }
 
 function parse_uri(uri) {
@@ -476,7 +479,7 @@ function parse_uri(uri) {
 function main() {
 	if (via_proxy !== '1') {
 		log('Stopping service...');
-		init_action('homeproxy', 'stop');
+		service_action('stop');
 	}
 
 	for (let url in subscription_urls) {
@@ -547,7 +550,7 @@ function main() {
 
 		if (via_proxy !== '1') {
 			log('Starting service...');
-			init_action('homeproxy', 'start');
+			service_action('start');
 		}
 
 		return false;
@@ -647,8 +650,8 @@ function main() {
 
 	if (need_restart) {
 		log('Restarting service...');
-		init_action('homeproxy', 'stop');
-		init_action('homeproxy', 'start');
+		service_action('stop');
+		service_action('start');
 	}
 
 	log(sprintf('%s nodes added, %s removed.', added, removed));
@@ -664,6 +667,6 @@ if (!isEmpty(subscription_urls))
 		log(e.stacktrace[0].context);
 
 		log('Restarting service...');
-		init_action('homeproxy', 'stop');
-		init_action('homeproxy', 'start');
+		service_action('stop');
+		service_action('start');
 	}


### PR DESCRIPTION
## Summary

- remove the deleted `luci.sys.init_action` import
- invoke the HomeProxy init script with the array form of `system()`
- preserve service stop/start behavior during subscription updates

This follows the backend migration used by openwrt/luci#8896. The array form executes the init script directly without shell interpolation.

## Testing

- `git diff --check`
- runtime-tested successfully on a GL-BE6500

Related: https://github.com/openwrt/luci/pull/8896