### PR TITLE
fix(node): correct socks5 scheme typo in share link import

### DIFF
--- a/htdocs/luci-static/resources/view/homeproxy/node.js
+++ b/htdocs/luci-static/resources/view/homeproxy/node.js
@@ -116,7 +116,7 @@ function parseShareLink(uri, features) {
 		case 'socks':
 		case 'socks4':
 		case 'socks4a':
-		case 'socsk5':
+		case 'socks5':
 		case 'socks5h':
 			url = new URL('http://' + uri[1]);
 


### PR DESCRIPTION
The share-link importer has a typo in the socks scheme switch: case 'socsk5' should be case 'socks5'. As a result, socks5:// share links match no case and fail to import. socks://, socks4://, socks4a:// and socks5h:// are unaffected.