### PR TITLE
feat(client): add reload button for homeproxy service

### DIFF
--- a/htdocs/luci-static/resources/view/homeproxy/client.js
+++ b/htdocs/luci-static/resources/view/homeproxy/client.js
@@ -10,6 +10,7 @@
 'require poll';
 'require rpc';
 'require uci';
+'require ui';
 'require validation';
 'require view';
 
@@ -35,6 +36,12 @@ const callWriteDomainList = rpc.declare({
 	object: 'luci.homeproxy',
 	method: 'acllist_write',
 	params: ['type', 'content'],
+	expect: { '': {} }
+});
+
+const callServiceReload = rpc.declare({
+	object: 'luci.homeproxy',
+	method: 'service_reload',
 	expect: { '': {} }
 });
 
@@ -156,6 +163,24 @@ return view.extend({
 		o.default = 'nil';
 		o.depends({'routing_mode': /^((?!custom).)+$/, 'proxy_mode': /^((?!redirect$).)+$/});
 		o.rmempty = false;
+		o.renderWidget = function(section_id, option_index, cfgvalue) {
+			const widget = form.ListValue.prototype.renderWidget.call(this, section_id, option_index, cfgvalue);
+			const container = E('div', { 'style': 'display:flex;flex-direction:column;gap:6px;align-items:flex-start;' }, [
+				widget,
+				E('button', {
+					'class': 'btn cbi-button cbi-button-action',
+					'click': ui.createHandlerFn(this, () => {
+						return L.resolveDefault(callServiceReload(), {}).then((res) => {
+							if (res && res.status === 0)
+								ui.addNotification(null, E('p', {}, _('Service reloaded.')));
+							else
+								ui.addNotification(null, E('p', {}, _('Failed to reload service.')));
+						});
+					})
+				}, [ _('Reload') ])
+			]);
+			return container;
+		}
 
 		o = s.taboption('routing', hp.CBIStaticList, 'main_udp_urltest_nodes', _('URLTest nodes'),
 			_('List of nodes to test.'));

--- a/po/templates/homeproxy.pot
+++ b/po/templates/homeproxy.pot
@@ -843,6 +843,10 @@ msgstr ""
 msgid "Failed to generate %s, error: %s."
 msgstr ""
 
+#: htdocs/luci-static/resources/view/homeproxy/client.js:177
+msgid "Failed to reload service."
+msgstr ""
+
 #: htdocs/luci-static/resources/homeproxy.js:261
 msgid "Failed to upload %s, error: %s."
 msgstr ""
@@ -1972,6 +1976,10 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
+#: htdocs/luci-static/resources/view/homeproxy/client.js:180
+msgid "Reload"
+msgstr ""
+
 #: htdocs/luci-static/resources/view/homeproxy/client.js:1336
 msgid "Remote"
 msgstr ""
@@ -2145,6 +2153,10 @@ msgstr ""
 
 #: root/usr/share/luci/menu.d/luci-app-homeproxy.json:38
 msgid "Service Status"
+msgstr ""
+
+#: htdocs/luci-static/resources/view/homeproxy/client.js:175
+msgid "Service reloaded."
 msgstr ""
 
 #: htdocs/luci-static/resources/view/homeproxy/client.js:1175

--- a/po/zh_Hans/homeproxy.po
+++ b/po/zh_Hans/homeproxy.po
@@ -866,6 +866,10 @@ msgstr "附加记录"
 msgid "Failed to generate %s, error: %s."
 msgstr "生成 %s 失败，错误：%s。"
 
+#: htdocs/luci-static/resources/view/homeproxy/client.js:177
+msgid "Failed to reload service."
+msgstr "服务重载失败。"
+
 #: htdocs/luci-static/resources/homeproxy.js:261
 msgid "Failed to upload %s, error: %s."
 msgstr "上传 %s 失败，错误：%s。"
@@ -2003,6 +2007,10 @@ msgstr "区域 ID"
 msgid "Reject"
 msgstr "拒绝"
 
+#: htdocs/luci-static/resources/view/homeproxy/client.js:180
+msgid "Reload"
+msgstr "重载"
+
 #: htdocs/luci-static/resources/view/homeproxy/client.js:1336
 msgid "Remote"
 msgstr "远程"
@@ -2177,6 +2185,10 @@ msgstr "服务器设置"
 #: root/usr/share/luci/menu.d/luci-app-homeproxy.json:38
 msgid "Service Status"
 msgstr "服务状态"
+
+#: htdocs/luci-static/resources/view/homeproxy/client.js:175
+msgid "Service reloaded."
+msgstr "服务已重载。"
 
 #: htdocs/luci-static/resources/view/homeproxy/client.js:1175
 msgid "Set domain strategy for this query."

--- a/root/usr/share/rpcd/ucode/luci.homeproxy
+++ b/root/usr/share/rpcd/ucode/luci.homeproxy
@@ -248,6 +248,12 @@ const methods = {
 			} else
 				return { status: 255, error: 'illegal type' };
 		}
+	},
+	service_reload: {
+		call: function() {
+			const exit_code = system('/etc/init.d/homeproxy reload');
+			return { status: exit_code };
+		}
 	}
 };
 


### PR DESCRIPTION
Add a reload button below the Main UDP node option in the client routing settings. Clicking it reloads the homeproxy service (via /etc/init.d/homeproxy reload) through the new luci.homeproxy.service_reload RPC method and shows a success/failure notification. Includes zh_Hans translations.

每次在访问控制-代理域名列表/直连域名列表 添加或者删除域名以后，点保存或者保存或应用都不能立即生效，需要切换一下节点或者切换一下开关才能生效，这个操作比较麻烦，所以添加一个重载按钮，每次做完 代理域名列表/直连域名列表 修改，都直接点重载即可。