### PR TITLE
fix(i18n): fix alrealy typo and half-width comma

### DIFF
--- a/htdocs/luci-static/resources/view/homeproxy/client.js
+++ b/htdocs/luci-static/resources/view/homeproxy/client.js
@@ -273,7 +273,7 @@ return view.extend({
 					if (!stubValidator.apply('port', i) && !stubValidator.apply('portrange', i))
 						return _('Expecting: %s').format(_('valid port value'));
 					if (ports.includes(i))
-						return _('Port %s alrealy exists!').format(i);
+						return _('Port %s already exists!').format(i);
 					ports = ports.concat(i);
 				}
 			}

--- a/po/templates/homeproxy.pot
+++ b/po/templates/homeproxy.pot
@@ -1748,7 +1748,7 @@ msgid "Port"
 msgstr ""
 
 #: htdocs/luci-static/resources/view/homeproxy/client.js:276
-msgid "Port %s alrealy exists!"
+msgid "Port %s already exists!"
 msgstr ""
 
 #: htdocs/luci-static/resources/view/homeproxy/client.js:582

--- a/po/zh_Hans/homeproxy.po
+++ b/po/zh_Hans/homeproxy.po
@@ -1616,7 +1616,7 @@ msgstr "New Reno"
 #: htdocs/luci-static/resources/view/homeproxy/server.js:400
 #: htdocs/luci-static/resources/view/homeproxy/server.js:417
 msgid "No TCP transport, plain HTTP is merged into the HTTP transport."
-msgstr "无 TCP 传输层, 纯 HTTP 已合并到 HTTP 传输层。"
+msgstr "无 TCP 传输层，纯 HTTP 已合并到 HTTP 传输层。"
 
 #: htdocs/luci-static/resources/view/homeproxy/node.js:789
 #: htdocs/luci-static/resources/view/homeproxy/server.js:415
@@ -1779,7 +1779,7 @@ msgid "Port"
 msgstr "端口"
 
 #: htdocs/luci-static/resources/view/homeproxy/client.js:276
-msgid "Port %s alrealy exists!"
+msgid "Port %s already exists!"
 msgstr "端口 %s 已存在！"
 
 #: htdocs/luci-static/resources/view/homeproxy/client.js:582


### PR DESCRIPTION
1.Fix the typo in "Port %s alrealy exists!" → "Port %s already exists!" (client.js, po, pot), keeping the existing zh_Hans translation.
2.Replace the half-width comma with a full-width comma in the zh_Hans translation of "No TCP transport, plain HTTP is merged into the HTTP transport." → "无 TCP 传输层，纯 HTTP 已合并到 HTTP 传输层。