### PR TITLE
fix(i18n): correct Peer pubkic key typo to Peer public key

### DIFF
--- a/htdocs/luci-static/resources/view/homeproxy/node.js
+++ b/htdocs/luci-static/resources/view/homeproxy/node.js
@@ -908,7 +908,7 @@ function renderNodeSettings(section, data, features, main_node, routing_mode) {
 	o.rmempty = false;
 	o.modalonly = true;
 
-	o = s.option(form.Value, 'wireguard_peer_public_key', _('Peer pubkic key'),
+	o = s.option(form.Value, 'wireguard_peer_public_key', _('Peer public key'),
 		_('WireGuard peer public key.'));
 	o.depends('type', 'wireguard');
 	o.validate = L.bind(hp.validateBase64Key, this, 44);

--- a/po/templates/homeproxy.pot
+++ b/po/templates/homeproxy.pot
@@ -1714,7 +1714,7 @@ msgid "Path"
 msgstr ""
 
 #: htdocs/luci-static/resources/view/homeproxy/node.js:911
-msgid "Peer pubkic key"
+msgid "Peer public key"
 msgstr ""
 
 #: htdocs/luci-static/resources/view/homeproxy/client.js:329

--- a/po/zh_Hans/homeproxy.po
+++ b/po/zh_Hans/homeproxy.po
@@ -1745,7 +1745,7 @@ msgid "Path"
 msgstr "路径"
 
 #: htdocs/luci-static/resources/view/homeproxy/node.js:911
-msgid "Peer pubkic key"
+msgid "Peer public key"
 msgstr "对端公钥"
 
 #: htdocs/luci-static/resources/view/homeproxy/client.js:329


### PR DESCRIPTION
Update the WireGuard peer public key label and the matching pot/po msgid; the zh_Hans translation is preserved.