### PR TITLE
fix: correct socks5 subscription scheme typo

### DIFF
--- a/root/etc/homeproxy/scripts/update_subscriptions.uc
+++ b/root/etc/homeproxy/scripts/update_subscriptions.uc
@@ -198,7 +198,7 @@ function parse_uri(uri) {
 		case 'socks':
 		case 'socks4':
 		case 'socks4a':
-		case 'socsk5':
+		case 'socks5':
 		case 'socks5h':
 			url = parseURL('http://' + uri[1]) || {};
 


### PR DESCRIPTION
Fix a typo in the subscription URI parser: `socsk5` -> `socks5`, so socks5 subscription links are parsed correctly.

One-line change in `root/etc/homeproxy/scripts/update_subscriptions.uc`.